### PR TITLE
feat: consolidate to seerr, fix WhatsApp reply + presence bugs (v1.3.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ backup/
 .specify/
 .scripts/
 .vscode/
+
+#Docs
+docs/

--- a/backend/drizzle/migrations/0016_rename_service_type_to_seerr.sql
+++ b/backend/drizzle/migrations/0016_rename_service_type_to_seerr.sql
@@ -1,0 +1,4 @@
+-- Rename legacy service types to the unified 'seerr' type
+-- Both overseerr and jellyseerr use the same /api/v1/ surface as seerr
+UPDATE media_service_configurations SET service_type = 'seerr' WHERE service_type IN ('overseerr', 'jellyseerr');--> statement-breakpoint
+UPDATE request_history SET service_type = 'seerr' WHERE service_type IN ('overseerr', 'jellyseerr');

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wamr-backend",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "WhatsApp Media Request Manager - Backend API",
   "main": "dist/index.js",
   "type": "module",

--- a/backend/src/api/controllers/requests.controller.ts
+++ b/backend/src/api/controllers/requests.controller.ts
@@ -244,7 +244,7 @@ export const approveRequest = async (
 
     try {
       // Submit to appropriate service
-      if (service.serviceType === 'overseerr') {
+      if (service.serviceType === 'seerr') {
         const client = new OverseerrClient(service.baseUrl, apiKey);
 
         if (request.mediaType === 'movie' && request.tmdbId) {
@@ -252,7 +252,7 @@ export const approveRequest = async (
           const defaultServer = radarrServers.find((s) => s.isDefault) || radarrServers[0];
 
           if (!defaultServer) {
-            throw new Error('No Radarr server configured in Overseerr');
+            throw new Error('No Radarr server configured in Seerr');
           }
 
           await client.requestMovie({
@@ -266,7 +266,7 @@ export const approveRequest = async (
           const defaultServer = sonarrServers.find((s) => s.isDefault) || sonarrServers[0];
 
           if (!defaultServer) {
-            throw new Error('No Sonarr server configured in Overseerr');
+            throw new Error('No Sonarr server configured in Seerr');
           }
 
           // Get selected seasons (stored as JSON in database)

--- a/backend/src/api/controllers/services.controller.ts
+++ b/backend/src/api/controllers/services.controller.ts
@@ -332,8 +332,6 @@ export const testConnection = async (
         result = await client.testConnection();
         break;
       }
-      case 'overseerr':
-      case 'jellyseerr':
       case 'seerr': {
         const client = new OverseerrClient(finalBaseUrl, finalApiKey);
         result = await client.testConnection();
@@ -426,10 +424,8 @@ export const getServiceMetadata = async (
         result = { qualityProfiles, rootFolders };
         break;
       }
-      case 'overseerr':
-      case 'jellyseerr':
       case 'seerr': {
-        // Overseerr/Jellyseerr/Seerr doesn't need metadata - it manages its own Radarr/Sonarr configurations
+        // Seerr doesn't need metadata - it manages its own Radarr/Sonarr configurations
         result = {};
         break;
       }

--- a/backend/src/api/controllers/services.controller.ts
+++ b/backend/src/api/controllers/services.controller.ts
@@ -332,7 +332,9 @@ export const testConnection = async (
         result = await client.testConnection();
         break;
       }
-      case 'overseerr': {
+      case 'overseerr':
+      case 'jellyseerr':
+      case 'seerr': {
         const client = new OverseerrClient(finalBaseUrl, finalApiKey);
         result = await client.testConnection();
         break;
@@ -424,8 +426,10 @@ export const getServiceMetadata = async (
         result = { qualityProfiles, rootFolders };
         break;
       }
-      case 'overseerr': {
-        // Overseerr doesn't need metadata - it manages its own Radarr/Sonarr configurations
+      case 'overseerr':
+      case 'jellyseerr':
+      case 'seerr': {
+        // Overseerr/Jellyseerr/Seerr doesn't need metadata - it manages its own Radarr/Sonarr configurations
         result = {};
         break;
       }

--- a/backend/src/api/controllers/whatsapp.controller.ts
+++ b/backend/src/api/controllers/whatsapp.controller.ts
@@ -222,6 +222,11 @@ export const updateMessageFilter = async (
       return;
     }
 
+    // Propagate the setting change to the running client without requiring a restart
+    if (markOnlineOnConnect !== undefined) {
+      whatsappClientService.setMarkOnlineOnConnect(markOnlineOnConnect);
+    }
+
     logger.info(
       { filterType, filterValue, processFromSelf, processGroups, markOnlineOnConnect },
       'Message filter updated'

--- a/backend/src/api/validators/service.validators.ts
+++ b/backend/src/api/validators/service.validators.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 /**
  * Service type enum
  */
-const serviceTypeSchema = z.enum(['radarr', 'sonarr', 'overseerr', 'jellyseerr', 'seerr']);
+const serviceTypeSchema = z.enum(['radarr', 'sonarr', 'seerr']);
 
 /**
  * URL validation (allows HTTP for localhost/internal IPs, requires HTTPS otherwise)

--- a/backend/src/api/validators/service.validators.ts
+++ b/backend/src/api/validators/service.validators.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 /**
  * Service type enum
  */
-const serviceTypeSchema = z.enum(['radarr', 'sonarr', 'overseerr']);
+const serviceTypeSchema = z.enum(['radarr', 'sonarr', 'overseerr', 'jellyseerr', 'seerr']);
 
 /**
  * URL validation (allows HTTP for localhost/internal IPs, requires HTTPS otherwise)

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -100,7 +100,7 @@ export const mediaServiceConfigurations = sqliteTable(
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
     serviceType: text('service_type', {
-      enum: ['radarr', 'sonarr', 'overseerr', 'jellyseerr', 'seerr'],
+      enum: ['radarr', 'sonarr', 'seerr'],
     }).notNull(),
     name: text('name').notNull(),
     baseUrl: text('base_url').notNull(),
@@ -146,7 +146,7 @@ export const requestHistory = sqliteTable(
     tmdbId: integer('tmdb_id'),
     tvdbId: integer('tvdb_id'),
     serviceType: text('service_type', {
-      enum: ['radarr', 'sonarr', 'overseerr', 'jellyseerr', 'seerr'],
+      enum: ['radarr', 'sonarr', 'seerr'],
     }),
     serviceConfigId: integer('service_config_id'),
     selectedSeasons: text('selected_seasons', { mode: 'json' }), // JSON array of season numbers for series requests

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -99,7 +99,9 @@ export const mediaServiceConfigurations = sqliteTable(
   'media_service_configurations',
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
-    serviceType: text('service_type', { enum: ['radarr', 'sonarr', 'overseerr'] }).notNull(),
+    serviceType: text('service_type', {
+      enum: ['radarr', 'sonarr', 'overseerr', 'jellyseerr', 'seerr'],
+    }).notNull(),
     name: text('name').notNull(),
     baseUrl: text('base_url').notNull(),
     apiKeyEncrypted: text('api_key_encrypted').notNull(),
@@ -143,7 +145,9 @@ export const requestHistory = sqliteTable(
     year: integer('year'),
     tmdbId: integer('tmdb_id'),
     tvdbId: integer('tvdb_id'),
-    serviceType: text('service_type', { enum: ['radarr', 'sonarr', 'overseerr'] }),
+    serviceType: text('service_type', {
+      enum: ['radarr', 'sonarr', 'overseerr', 'jellyseerr', 'seerr'],
+    }),
     serviceConfigId: integer('service_config_id'),
     selectedSeasons: text('selected_seasons', { mode: 'json' }), // JSON array of season numbers for series requests
     notifiedSeasons: text('notified_seasons', { mode: 'json' }), // JSON array of season numbers that user has been notified about

--- a/backend/src/models/media-service-config.model.ts
+++ b/backend/src/models/media-service-config.model.ts
@@ -6,7 +6,7 @@
 /**
  * Service types supported by the system
  */
-export type ServiceType = 'radarr' | 'sonarr' | 'overseerr';
+export type ServiceType = 'radarr' | 'sonarr' | 'overseerr' | 'jellyseerr' | 'seerr';
 
 /**
  * Media service configuration status

--- a/backend/src/models/media-service-config.model.ts
+++ b/backend/src/models/media-service-config.model.ts
@@ -6,7 +6,7 @@
 /**
  * Service types supported by the system
  */
-export type ServiceType = 'radarr' | 'sonarr' | 'overseerr' | 'jellyseerr' | 'seerr';
+export type ServiceType = 'radarr' | 'sonarr' | 'seerr';
 
 /**
  * Media service configuration status

--- a/backend/src/models/request-history.model.ts
+++ b/backend/src/models/request-history.model.ts
@@ -18,7 +18,7 @@ export type MediaType = 'movie' | 'series' | 'both';
 /**
  * Service type for the request
  */
-export type ServiceType = 'radarr' | 'sonarr' | 'overseerr' | 'jellyseerr' | 'seerr';
+export type ServiceType = 'radarr' | 'sonarr' | 'seerr';
 
 /**
  * Conversation log message structure

--- a/backend/src/models/request-history.model.ts
+++ b/backend/src/models/request-history.model.ts
@@ -18,7 +18,7 @@ export type MediaType = 'movie' | 'series' | 'both';
 /**
  * Service type for the request
  */
-export type ServiceType = 'radarr' | 'sonarr' | 'overseerr';
+export type ServiceType = 'radarr' | 'sonarr' | 'overseerr' | 'jellyseerr' | 'seerr';
 
 /**
  * Conversation log message structure

--- a/backend/src/services/conversation/conversation.service.ts
+++ b/backend/src/services/conversation/conversation.service.ts
@@ -412,12 +412,12 @@ export class ConversationService {
     // Check if this is a TV series - if so, fetch season details and ask for season selection
     if (selectedResult.mediaType === 'series' && selectedResult.tmdbId) {
       try {
-        // Get Overseerr service configuration
-        const overseerrConfigs = await mediaServiceConfigRepository.findByType('overseerr');
+        // Get Seerr service configuration
+        const overseerrConfigs = await mediaServiceConfigRepository.findByType('seerr');
         const overseerrConfig = overseerrConfigs.find((c) => c.enabled);
 
         if (overseerrConfig && overseerrConfig.apiKeyEncrypted) {
-          // Fetch TV details including season information from Overseerr
+          // Fetch TV details including season information from Seerr
           const { OverseerrClient } = await import('../integrations/overseerr.client.js');
           const { encryptionService } = await import('../encryption/encryption.service.js');
 
@@ -950,18 +950,13 @@ export class ConversationService {
 
       // Select the most appropriate service for the media type.
       // Prefer a type-specific service (radarr for movies, sonarr for series),
-      // then fall back to overseerr/jellyseerr/seerr, then the highest-priority service.
+      // then fall back to seerr, then the highest-priority service.
       const mediaType = selectedResult.mediaType;
       const preferredServiceType = mediaType === 'movie' ? 'radarr' : 'sonarr';
 
       let service =
         enabledServices.find((s) => s.serviceType === preferredServiceType) ??
-        enabledServices.find(
-          (s) =>
-            s.serviceType === 'overseerr' ||
-            s.serviceType === 'jellyseerr' ||
-            s.serviceType === 'seerr'
-        ) ??
+        enabledServices.find((s) => s.serviceType === 'seerr') ??
         enabledServices[0];
 
       logger.info(
@@ -980,7 +975,8 @@ export class ConversationService {
         selectedResult,
         service.id,
         session.selectedSeasons ?? undefined,
-        contactName
+        contactName,
+        this.activeReplyJids.get(sessionId)
       );
 
       // Note: The request approval service already sends WhatsApp notifications to the user,

--- a/backend/src/services/conversation/conversation.service.ts
+++ b/backend/src/services/conversation/conversation.service.ts
@@ -948,8 +948,26 @@ export class ConversationService {
         return;
       }
 
-      // Use highest priority service
-      const service = enabledServices[0];
+      // Select the most appropriate service for the media type.
+      // Prefer a type-specific service (radarr for movies, sonarr for series),
+      // then fall back to overseerr/jellyseerr/seerr, then the highest-priority service.
+      const mediaType = selectedResult.mediaType;
+      const preferredServiceType = mediaType === 'movie' ? 'radarr' : 'sonarr';
+
+      let service =
+        enabledServices.find((s) => s.serviceType === preferredServiceType) ??
+        enabledServices.find(
+          (s) =>
+            s.serviceType === 'overseerr' ||
+            s.serviceType === 'jellyseerr' ||
+            s.serviceType === 'seerr'
+        ) ??
+        enabledServices[0];
+
+      logger.info(
+        { sessionId, mediaType, selectedServiceType: service.serviceType, serviceId: service.id },
+        'Selected service for media request'
+      );
 
       // Get phone number and contact name for this session
       const phoneNumber = this.activePhoneNumbers.get(sessionId);

--- a/backend/src/services/conversation/request-approval.service.ts
+++ b/backend/src/services/conversation/request-approval.service.ts
@@ -26,8 +26,11 @@ export class RequestApprovalService {
     selectedResult: NormalizedResult,
     serviceConfigId: number,
     selectedSeasons?: number[],
-    contactName?: string
+    contactName?: string,
+    replyJid?: string
   ): Promise<{ success: boolean; errorMessage?: string; status: string }> {
+    // Use replyJid as fallback when phoneNumber is not available (LID accounts)
+    const sendTarget = phoneNumber ?? replyJid;
     try {
       // Get auto-approval mode from the active WhatsApp connection (admin's connection)
       // Note: We use getActive() because approval mode is a system-wide setting,
@@ -95,11 +98,11 @@ export class RequestApprovalService {
         });
 
         // Send rejection message
-        if (phoneNumber) {
+        if (sendTarget) {
           const emoji = mediaType === 'movie' ? '🎬' : '📺';
           const yearStr = selectedResult.year ? ` (${selectedResult.year})` : '';
           const message = `❌ Your request was automatically declined.\n\n${emoji} *${selectedResult.title}${yearStr}*\n\nReason: Automatic approval is currently disabled.`;
-          await whatsappClientService.sendMessage(phoneNumber, message);
+          await whatsappClientService.sendMessage(sendTarget, message);
         }
 
         // Emit WebSocket event
@@ -129,11 +132,11 @@ export class RequestApprovalService {
         });
 
         // Send pending message
-        if (phoneNumber) {
+        if (sendTarget) {
           const emoji = mediaType === 'movie' ? '🎬' : '📺';
           const yearStr = selectedResult.year ? ` (${selectedResult.year})` : '';
           const message = `⏳ Your request is pending approval.\n\n${emoji} *${selectedResult.title}${yearStr}*\n\nYou will be notified once an administrator reviews your request.`;
-          await whatsappClientService.sendMessage(phoneNumber, message);
+          await whatsappClientService.sendMessage(sendTarget, message);
         }
 
         // Emit WebSocket event
@@ -186,11 +189,11 @@ export class RequestApprovalService {
           });
 
           // Send success message
-          if (phoneNumber) {
+          if (sendTarget) {
             const emoji = mediaType === 'movie' ? '🎬' : '📺';
             const yearStr = selectedResult.year ? ` (${selectedResult.year})` : '';
             const message = `✅ Request submitted successfully!\n\n${emoji} *${selectedResult.title}${yearStr}* has been added to the queue.\n\nYou will be notified when it's available.`;
-            await whatsappClientService.sendMessage(phoneNumber, message);
+            await whatsappClientService.sendMessage(sendTarget, message);
           }
 
           // Emit WebSocket event
@@ -222,11 +225,11 @@ export class RequestApprovalService {
           });
 
           // Send failure message
-          if (phoneNumber) {
+          if (sendTarget) {
             const emoji = mediaType === 'movie' ? '🎬' : '📺';
             const yearStr = selectedResult.year ? ` (${selectedResult.year})` : '';
             const message = `❌ Failed to submit your request.\n\n${emoji} *${selectedResult.title}${yearStr}*\n\n${result.errorMessage || 'An error occurred. Please try again later.'}`;
-            await whatsappClientService.sendMessage(phoneNumber, message);
+            await whatsappClientService.sendMessage(sendTarget, message);
           }
 
           // Emit WebSocket event
@@ -265,7 +268,7 @@ export class RequestApprovalService {
     try {
       const mediaType = selectedResult.mediaType;
 
-      if (serviceType === 'overseerr' || serviceType === 'jellyseerr' || serviceType === 'seerr') {
+      if (serviceType === 'seerr') {
         const client = new OverseerrClient(baseUrl, apiKey);
 
         if (mediaType === 'movie' && selectedResult.tmdbId) {
@@ -273,13 +276,7 @@ export class RequestApprovalService {
           const defaultServer = radarrServers.find((s) => s.isDefault) || radarrServers[0];
 
           if (!defaultServer) {
-            const serviceName =
-              serviceType === 'seerr'
-                ? 'Seerr'
-                : serviceType === 'jellyseerr'
-                  ? 'Jellyseerr'
-                  : 'Overseerr';
-            throw new Error(`No Radarr server configured in ${serviceName}`);
+            throw new Error(`No Radarr server configured in Seerr`);
           }
 
           await client.requestMovie({
@@ -293,13 +290,7 @@ export class RequestApprovalService {
           const defaultServer = sonarrServers.find((s) => s.isDefault) || sonarrServers[0];
 
           if (!defaultServer) {
-            const serviceName =
-              serviceType === 'seerr'
-                ? 'Seerr'
-                : serviceType === 'jellyseerr'
-                  ? 'Jellyseerr'
-                  : 'Overseerr';
-            throw new Error(`No Sonarr server configured in ${serviceName}`);
+            throw new Error(`No Sonarr server configured in Seerr`);
           }
 
           await client.requestSeries({

--- a/backend/src/services/conversation/request-approval.service.ts
+++ b/backend/src/services/conversation/request-approval.service.ts
@@ -95,6 +95,7 @@ export class RequestApprovalService {
           selectedSeasons,
           status: 'REJECTED',
           adminNotes: 'Auto-rejected by system settings',
+          replyJid: replyJid ?? undefined,
         });
 
         // Send rejection message
@@ -129,6 +130,7 @@ export class RequestApprovalService {
           serviceConfigId,
           selectedSeasons,
           status: 'PENDING',
+          replyJid: replyJid ?? undefined,
         });
 
         // Send pending message
@@ -186,6 +188,7 @@ export class RequestApprovalService {
             selectedSeasons,
             status: 'SUBMITTED',
             submittedAt: new Date().toISOString(),
+            replyJid: replyJid ?? undefined,
           });
 
           // Send success message

--- a/backend/src/services/conversation/request-approval.service.ts
+++ b/backend/src/services/conversation/request-approval.service.ts
@@ -265,7 +265,7 @@ export class RequestApprovalService {
     try {
       const mediaType = selectedResult.mediaType;
 
-      if (serviceType === 'overseerr') {
+      if (serviceType === 'overseerr' || serviceType === 'jellyseerr' || serviceType === 'seerr') {
         const client = new OverseerrClient(baseUrl, apiKey);
 
         if (mediaType === 'movie' && selectedResult.tmdbId) {
@@ -273,7 +273,13 @@ export class RequestApprovalService {
           const defaultServer = radarrServers.find((s) => s.isDefault) || radarrServers[0];
 
           if (!defaultServer) {
-            throw new Error('No Radarr server configured in Overseerr');
+            const serviceName =
+              serviceType === 'seerr'
+                ? 'Seerr'
+                : serviceType === 'jellyseerr'
+                  ? 'Jellyseerr'
+                  : 'Overseerr';
+            throw new Error(`No Radarr server configured in ${serviceName}`);
           }
 
           await client.requestMovie({
@@ -287,7 +293,13 @@ export class RequestApprovalService {
           const defaultServer = sonarrServers.find((s) => s.isDefault) || sonarrServers[0];
 
           if (!defaultServer) {
-            throw new Error('No Sonarr server configured in Overseerr');
+            const serviceName =
+              serviceType === 'seerr'
+                ? 'Seerr'
+                : serviceType === 'jellyseerr'
+                  ? 'Jellyseerr'
+                  : 'Overseerr';
+            throw new Error(`No Sonarr server configured in ${serviceName}`);
           }
 
           await client.requestSeries({
@@ -342,6 +354,14 @@ export class RequestApprovalService {
           monitored: true,
           searchForMissingEpisodes: true,
         });
+      } else if (serviceType === 'radarr' && mediaType === 'series') {
+        throw new Error(
+          "Sorry, the configured service (Radarr) can't handle TV series requests. Please contact your admin."
+        );
+      } else if (serviceType === 'sonarr' && mediaType === 'movie') {
+        throw new Error(
+          "Sorry, the configured service (Sonarr) can't handle movie requests. Please contact your admin."
+        );
       }
 
       return { success: true };

--- a/backend/src/services/media-monitoring/media-monitoring.service.ts
+++ b/backend/src/services/media-monitoring/media-monitoring.service.ts
@@ -132,11 +132,7 @@ class MediaMonitoringService {
     } = { isAvailable: false };
 
     try {
-      if (
-        service.serviceType === 'overseerr' ||
-        service.serviceType === 'jellyseerr' ||
-        service.serviceType === 'seerr'
-      ) {
+      if (service.serviceType === 'seerr') {
         availabilityInfo = await this.checkOverseerrStatus(service.baseUrl, apiKey, request);
       } else if (service.serviceType === 'radarr' && request.mediaType === 'movie') {
         const isAvailable = await this.checkRadarrStatus(service.baseUrl, apiKey, request);

--- a/backend/src/services/media-monitoring/media-monitoring.service.ts
+++ b/backend/src/services/media-monitoring/media-monitoring.service.ts
@@ -132,7 +132,11 @@ class MediaMonitoringService {
     } = { isAvailable: false };
 
     try {
-      if (service.serviceType === 'overseerr') {
+      if (
+        service.serviceType === 'overseerr' ||
+        service.serviceType === 'jellyseerr' ||
+        service.serviceType === 'seerr'
+      ) {
         availabilityInfo = await this.checkOverseerrStatus(service.baseUrl, apiKey, request);
       } else if (service.serviceType === 'radarr' && request.mediaType === 'movie') {
         const isAvailable = await this.checkRadarrStatus(service.baseUrl, apiKey, request);

--- a/backend/src/services/media-search/media-search.service.ts
+++ b/backend/src/services/media-search/media-search.service.ts
@@ -87,17 +87,14 @@ class MediaSearchService {
     let servicesToSearch: string[];
     if (searchBoth) {
       // Search all services when ambiguous
-      servicesToSearch = ['radarr', 'sonarr', 'overseerr', 'jellyseerr', 'seerr'];
+      servicesToSearch = ['radarr', 'sonarr', 'seerr'];
       logger.info('Starting comprehensive media search (movies + series)', {
         query,
         services: servicesToSearch,
       });
     } else {
       // Search specific services based on media type
-      servicesToSearch =
-        mediaType === 'movie'
-          ? ['radarr', 'overseerr', 'jellyseerr', 'seerr']
-          : ['sonarr', 'overseerr', 'jellyseerr', 'seerr'];
+      servicesToSearch = mediaType === 'movie' ? ['radarr', 'seerr'] : ['sonarr', 'seerr'];
       logger.info('Starting media search', {
         mediaType,
         query,
@@ -124,11 +121,7 @@ class MediaSearchService {
 
     // Search all services in parallel with timeout
     const searchPromises = servicesToSearch.map((serviceType) =>
-      this.searchService(
-        serviceType as 'radarr' | 'sonarr' | 'overseerr' | 'jellyseerr' | 'seerr',
-        query,
-        effectiveMediaType
-      )
+      this.searchService(serviceType as 'radarr' | 'sonarr' | 'seerr', query, effectiveMediaType)
     );
 
     const results = await Promise.allSettled(searchPromises);
@@ -150,12 +143,8 @@ class MediaSearchService {
           radarrResults = result.value;
         } else if (serviceType === 'sonarr') {
           sonarrResults = result.value;
-        } else if (
-          serviceType === 'overseerr' ||
-          serviceType === 'jellyseerr' ||
-          serviceType === 'seerr'
-        ) {
-          // Merge seerr/jellyseerr/overseerr results (same shape)
+        } else if (serviceType === 'seerr') {
+          // Merge seerr results (same shape as Overseerr API)
           overseerrResults = [...overseerrResults, ...result.value];
         }
       } else if (result.status === 'rejected') {
@@ -205,7 +194,7 @@ class MediaSearchService {
    * Search a specific service with timeout
    */
   private async searchService(
-    serviceType: 'radarr' | 'sonarr' | 'overseerr' | 'jellyseerr' | 'seerr',
+    serviceType: 'radarr' | 'sonarr' | 'seerr',
     query: string,
     mediaType: MediaType
   ): Promise<any[] | null> {
@@ -291,7 +280,7 @@ class MediaSearchService {
    * Execute search against specific service client
    */
   private async executeSearch(
-    serviceType: 'radarr' | 'sonarr' | 'overseerr' | 'jellyseerr' | 'seerr',
+    serviceType: 'radarr' | 'sonarr' | 'seerr',
     baseUrl: string,
     apiKey: string,
     query: string,
@@ -308,20 +297,18 @@ class MediaSearchService {
         return await client.searchSeries(query);
       }
 
-      case 'overseerr':
-      case 'jellyseerr':
       case 'seerr': {
         const client = new OverseerrClient(baseUrl, apiKey);
         const searchResult = await client.search(query);
 
-        logger.debug('Overseerr search results before filtering', {
+        logger.debug('Seerr search results before filtering', {
           query,
           mediaType,
           totalResults: searchResult.results.length,
           resultTypes: searchResult.results.map((r) => r.mediaType),
         });
 
-        // Filter Overseerr results by media type
+        // Filter Seerr results by media type
         const filtered = searchResult.results.filter((result) => {
           if (mediaType === 'movie') {
             return result.mediaType === 'movie';
@@ -333,7 +320,7 @@ class MediaSearchService {
           }
         });
 
-        logger.debug('Overseerr search results after filtering', {
+        logger.debug('Seerr search results after filtering', {
           query,
           mediaType,
           filteredCount: filtered.length,
@@ -355,10 +342,9 @@ class MediaSearchService {
     mediaType: MediaType
   ): Promise<{ serviceType: string; serviceConfigId: number } | null> {
     try {
-      // For movies: check radarr first, then overseerr
-      // For series: check sonarr first, then overseerr
+      // For movies: check radarr first, then seerr
+      // For series: check sonarr first, then seerr
       const primaryService = mediaType === 'movie' ? 'radarr' : 'sonarr';
-      const fallbackService = 'overseerr';
 
       // Check primary service
       const primaryConfigs = await mediaServiceConfigRepository.findEnabledByType(primaryService);
@@ -369,26 +355,7 @@ class MediaSearchService {
         };
       }
 
-      // Fallback to overseerr or jellyseerr
-      const overseerrConfigs =
-        await mediaServiceConfigRepository.findEnabledByType(fallbackService);
-      if (overseerrConfigs.length > 0) {
-        return {
-          serviceType: fallbackService,
-          serviceConfigId: overseerrConfigs[0].id,
-        };
-      }
-
-      // Also check jellyseerr as a fallback
-      const jellyseerrConfigs = await mediaServiceConfigRepository.findEnabledByType('jellyseerr');
-      if (jellyseerrConfigs.length > 0) {
-        return {
-          serviceType: 'jellyseerr',
-          serviceConfigId: jellyseerrConfigs[0].id,
-        };
-      }
-
-      // Also check seerr as a fallback
+      // Fallback to seerr
       const seerrConfigs = await mediaServiceConfigRepository.findEnabledByType('seerr');
       if (seerrConfigs.length > 0) {
         return {

--- a/backend/src/services/media-search/media-search.service.ts
+++ b/backend/src/services/media-search/media-search.service.ts
@@ -87,14 +87,17 @@ class MediaSearchService {
     let servicesToSearch: string[];
     if (searchBoth) {
       // Search all services when ambiguous
-      servicesToSearch = ['radarr', 'sonarr', 'overseerr'];
+      servicesToSearch = ['radarr', 'sonarr', 'overseerr', 'jellyseerr', 'seerr'];
       logger.info('Starting comprehensive media search (movies + series)', {
         query,
         services: servicesToSearch,
       });
     } else {
       // Search specific services based on media type
-      servicesToSearch = mediaType === 'movie' ? ['radarr', 'overseerr'] : ['sonarr', 'overseerr'];
+      servicesToSearch =
+        mediaType === 'movie'
+          ? ['radarr', 'overseerr', 'jellyseerr', 'seerr']
+          : ['sonarr', 'overseerr', 'jellyseerr', 'seerr'];
       logger.info('Starting media search', {
         mediaType,
         query,
@@ -122,7 +125,7 @@ class MediaSearchService {
     // Search all services in parallel with timeout
     const searchPromises = servicesToSearch.map((serviceType) =>
       this.searchService(
-        serviceType as 'radarr' | 'sonarr' | 'overseerr',
+        serviceType as 'radarr' | 'sonarr' | 'overseerr' | 'jellyseerr' | 'seerr',
         query,
         effectiveMediaType
       )
@@ -140,23 +143,29 @@ class MediaSearchService {
     results.forEach((result, index) => {
       const serviceType = servicesToSearch[index];
 
-      if (result.status === 'fulfilled' && result.value) {
+      if (result.status === 'fulfilled' && result.value !== null) {
         searchedServices.push(serviceType);
 
         if (serviceType === 'radarr') {
           radarrResults = result.value;
         } else if (serviceType === 'sonarr') {
           sonarrResults = result.value;
-        } else if (serviceType === 'overseerr') {
-          overseerrResults = result.value;
+        } else if (
+          serviceType === 'overseerr' ||
+          serviceType === 'jellyseerr' ||
+          serviceType === 'seerr'
+        ) {
+          // Merge seerr/jellyseerr/overseerr results (same shape)
+          overseerrResults = [...overseerrResults, ...result.value];
         }
-      } else {
+      } else if (result.status === 'rejected') {
         failedServices.push(serviceType);
         logger.warn('Service search failed', {
           service: serviceType,
-          error: result.status === 'rejected' ? result.reason : 'Unknown error',
+          error: result.reason,
         });
       }
+      // result.value === null means service not configured — skip silently
     });
 
     // Normalize and combine results
@@ -196,17 +205,17 @@ class MediaSearchService {
    * Search a specific service with timeout
    */
   private async searchService(
-    serviceType: 'radarr' | 'sonarr' | 'overseerr',
+    serviceType: 'radarr' | 'sonarr' | 'overseerr' | 'jellyseerr' | 'seerr',
     query: string,
     mediaType: MediaType
-  ): Promise<any[]> {
+  ): Promise<any[] | null> {
     try {
       // Get enabled services of this type, ordered by priority
       const configs = await mediaServiceConfigRepository.findEnabledByType(serviceType);
 
       if (configs.length === 0) {
         logger.debug('No enabled services found', { serviceType });
-        return [];
+        return null;
       }
 
       // Use highest priority service (first in array)
@@ -282,7 +291,7 @@ class MediaSearchService {
    * Execute search against specific service client
    */
   private async executeSearch(
-    serviceType: 'radarr' | 'sonarr' | 'overseerr',
+    serviceType: 'radarr' | 'sonarr' | 'overseerr' | 'jellyseerr' | 'seerr',
     baseUrl: string,
     apiKey: string,
     query: string,
@@ -299,7 +308,9 @@ class MediaSearchService {
         return await client.searchSeries(query);
       }
 
-      case 'overseerr': {
+      case 'overseerr':
+      case 'jellyseerr':
+      case 'seerr': {
         const client = new OverseerrClient(baseUrl, apiKey);
         const searchResult = await client.search(query);
 
@@ -358,13 +369,31 @@ class MediaSearchService {
         };
       }
 
-      // Fallback to overseerr
+      // Fallback to overseerr or jellyseerr
       const overseerrConfigs =
         await mediaServiceConfigRepository.findEnabledByType(fallbackService);
       if (overseerrConfigs.length > 0) {
         return {
           serviceType: fallbackService,
           serviceConfigId: overseerrConfigs[0].id,
+        };
+      }
+
+      // Also check jellyseerr as a fallback
+      const jellyseerrConfigs = await mediaServiceConfigRepository.findEnabledByType('jellyseerr');
+      if (jellyseerrConfigs.length > 0) {
+        return {
+          serviceType: 'jellyseerr',
+          serviceConfigId: jellyseerrConfigs[0].id,
+        };
+      }
+
+      // Also check seerr as a fallback
+      const seerrConfigs = await mediaServiceConfigRepository.findEnabledByType('seerr');
+      if (seerrConfigs.length > 0) {
+        return {
+          serviceType: 'seerr',
+          serviceConfigId: seerrConfigs[0].id,
         };
       }
 

--- a/backend/src/services/media-search/result-normalizer.ts
+++ b/backend/src/services/media-search/result-normalizer.ts
@@ -113,7 +113,7 @@ class ResultNormalizerService {
    */
   normalizeOverseerrResults(
     results: OverseerrSearchResult[],
-    source: ServiceType = 'overseerr'
+    source: ServiceType = 'seerr'
   ): NormalizedResult[] {
     try {
       logger.debug('Normalizing Overseerr results', {
@@ -199,7 +199,7 @@ class ResultNormalizerService {
       logger.debug('Combining results from multiple sources', {
         radarr: radarrResults.length,
         sonarr: sonarrResults.length,
-        overseerr: overseerrResults.length,
+        seerr: overseerrResults.length,
       });
 
       // Normalize results from each source

--- a/backend/src/services/notifications/admin-notification.service.ts
+++ b/backend/src/services/notifications/admin-notification.service.ts
@@ -474,7 +474,7 @@ class AdminNotificationService {
       const apiKey = encryptionService.decrypt(service.apiKeyEncrypted);
 
       try {
-        if (service.serviceType === 'overseerr') {
+        if (service.serviceType === 'seerr') {
           const client = new OverseerrClient(service.baseUrl, apiKey);
 
           if (request.mediaType === 'movie' && request.tmdbId) {
@@ -482,7 +482,7 @@ class AdminNotificationService {
             const defaultServer = radarrServers.find((s) => s.isDefault) || radarrServers[0];
 
             if (!defaultServer) {
-              throw new Error('No Radarr server configured in Overseerr');
+              throw new Error('No Radarr server configured in Seerr');
             }
 
             await client.requestMovie({
@@ -496,7 +496,7 @@ class AdminNotificationService {
             const defaultServer = sonarrServers.find((s) => s.isDefault) || sonarrServers[0];
 
             if (!defaultServer) {
-              throw new Error('No Sonarr server configured in Overseerr');
+              throw new Error('No Sonarr server configured in Seerr');
             }
 
             const selectedSeasons = request.selectedSeasons as number[] | null;

--- a/backend/src/services/whatsapp/whatsapp-client.service.ts
+++ b/backend/src/services/whatsapp/whatsapp-client.service.ts
@@ -40,7 +40,7 @@ class WhatsAppClientService {
   private isInitializing = false;
   private hasCalledReady = false; // Track if ready callback has been called for current connection
   private initializationTimeout: NodeJS.Timeout | null = null;
-  private markOnlineOnConnect = false; // Cached setting — updated on each initialize()
+  private markOnlineOnConnect = false; // Updated on initialize() and via setMarkOnlineOnConnect()
 
   private qrCodeCallback: ((qr: string) => void) | null = null;
   private messageCallback: ((message: BaileysMessage) => void) | null = null;
@@ -446,6 +446,15 @@ class WhatsAppClientService {
       logger.error({ error, recipient: recipient.slice(-4) }, 'Failed to send message');
       throw error;
     }
+  }
+
+  /**
+   * Update the cached markOnlineOnConnect setting without restarting the client.
+   * Called by the controller when the user changes the setting in the UI.
+   */
+  setMarkOnlineOnConnect(value: boolean): void {
+    this.markOnlineOnConnect = value;
+    logger.info({ value }, 'Updated markOnlineOnConnect setting');
   }
 
   /**

--- a/backend/src/services/whatsapp/whatsapp-client.service.ts
+++ b/backend/src/services/whatsapp/whatsapp-client.service.ts
@@ -40,6 +40,7 @@ class WhatsAppClientService {
   private isInitializing = false;
   private hasCalledReady = false; // Track if ready callback has been called for current connection
   private initializationTimeout: NodeJS.Timeout | null = null;
+  private markOnlineOnConnect = false; // Cached setting — updated on each initialize()
 
   private qrCodeCallback: ((qr: string) => void) | null = null;
   private messageCallback: ((message: BaileysMessage) => void) | null = null;
@@ -103,7 +104,8 @@ class WhatsAppClientService {
 
       // Read persisted connection settings
       const connectionSettings = await whatsappConnectionRepository.getFirst();
-      const markOnlineOnConnect = connectionSettings?.markOnlineOnConnect ?? false;
+      this.markOnlineOnConnect = connectionSettings?.markOnlineOnConnect ?? false;
+      const markOnlineOnConnect = this.markOnlineOnConnect;
 
       // Fetch the latest WA web version — WhatsApp rejects outdated versions with 405
       let waVersion: [number, number, number] = [2, 3000, 1035194821]; // fallback to current known-good
@@ -429,6 +431,17 @@ class WhatsAppClientService {
         { recipient: recipient.slice(-4), messageId: result?.key?.id },
         'Message sent successfully'
       );
+
+      // If markOnlineOnConnect is disabled, restore unavailable presence after sending.
+      // Baileys internally sends 'available' before each outgoing message, which would
+      // show the account as online even when the user has opted out.
+      if (!this.markOnlineOnConnect) {
+        try {
+          await this.sock.sendPresenceUpdate('unavailable');
+        } catch (presenceError) {
+          logger.debug({ presenceError }, 'Failed to restore unavailable presence after send');
+        }
+      }
     } catch (error) {
       logger.error({ error, recipient: recipient.slice(-4) }, 'Failed to send message');
       throw error;

--- a/backend/src/types/conversation-state.types.ts
+++ b/backend/src/types/conversation-state.types.ts
@@ -30,7 +30,7 @@ export interface NormalizedResult {
   overview: string | null;
   posterPath: string | null;
   serviceId: number; // Which service returned this result
-  serviceType: 'radarr' | 'sonarr' | 'overseerr';
+  serviceType: 'radarr' | 'sonarr' | 'seerr';
   // TV series specific
   seasonCount?: number | null;
 }

--- a/backend/src/types/media-result.types.ts
+++ b/backend/src/types/media-result.types.ts
@@ -6,7 +6,7 @@ export type MediaType = 'movie' | 'series' | 'both';
 /**
  * Service types that provide media search
  */
-export type ServiceType = 'radarr' | 'sonarr' | 'overseerr';
+export type ServiceType = 'radarr' | 'sonarr' | 'seerr';
 
 /**
  * Normalized search result structure
@@ -144,7 +144,7 @@ export function normalizeSonarrResult(
  */
 export function normalizeOverseerrResult(
   result: OverseerrSearchResult,
-  source: ServiceType = 'overseerr'
+  source: ServiceType = 'seerr'
 ): NormalizedResult {
   const mediaType = result.mediaType === 'movie' ? 'movie' : 'series';
   const title = result.title || result.name || 'Unknown';

--- a/backend/tests/unit/controllers/requests.controller.test.ts
+++ b/backend/tests/unit/controllers/requests.controller.test.ts
@@ -423,8 +423,8 @@ describe('Requests Controller', () => {
       };
       const mockService = {
         id: 1,
-        serviceType: 'overseerr',
-        baseUrl: 'http://overseerr.example.com',
+        serviceType: 'seerr',
+        baseUrl: 'http://seerr.example.com',
         apiKeyEncrypted: 'encrypted-key',
         enabled: true,
       };
@@ -490,8 +490,8 @@ describe('Requests Controller', () => {
       };
       const mockService = {
         id: 1,
-        serviceType: 'overseerr',
-        baseUrl: 'http://overseerr.example.com',
+        serviceType: 'seerr',
+        baseUrl: 'http://seerr.example.com',
         apiKeyEncrypted: 'encrypted-key',
         enabled: true,
       };
@@ -664,8 +664,8 @@ describe('Requests Controller', () => {
       };
       const mockService = {
         id: 1,
-        serviceType: 'overseerr',
-        baseUrl: 'http://overseerr.example.com',
+        serviceType: 'seerr',
+        baseUrl: 'http://seerr.example.com',
         apiKeyEncrypted: 'encrypted-key',
         enabled: true,
       };
@@ -689,7 +689,7 @@ describe('Requests Controller', () => {
       expect(mockClientInstance.getRadarrServers).toHaveBeenCalled();
       expect(requestHistoryRepository.update).toHaveBeenCalledWith(1, {
         status: 'FAILED',
-        errorMessage: 'No Radarr server configured in Overseerr',
+        errorMessage: 'No Radarr server configured in Seerr',
         updatedAt: expect.any(String),
       });
       expect(mockResponse.status).toHaveBeenCalledWith(500);
@@ -706,8 +706,8 @@ describe('Requests Controller', () => {
       };
       const mockService = {
         id: 1,
-        serviceType: 'overseerr',
-        baseUrl: 'http://overseerr.example.com',
+        serviceType: 'seerr',
+        baseUrl: 'http://seerr.example.com',
         apiKeyEncrypted: 'encrypted-key',
         enabled: true,
       };
@@ -731,7 +731,7 @@ describe('Requests Controller', () => {
       expect(mockClientInstance.getSonarrServers).toHaveBeenCalled();
       expect(requestHistoryRepository.update).toHaveBeenCalledWith(1, {
         status: 'FAILED',
-        errorMessage: 'No Sonarr server configured in Overseerr',
+        errorMessage: 'No Sonarr server configured in Seerr',
         updatedAt: expect.any(String),
       });
       expect(mockResponse.status).toHaveBeenCalledWith(500);

--- a/backend/tests/unit/controllers/services.controller.test.ts
+++ b/backend/tests/unit/controllers/services.controller.test.ts
@@ -125,8 +125,8 @@ describe('Services Controller', () => {
     it('should test Overseerr connection successfully', async () => {
       const mockResult = { success: true, version: '1.0.0' };
       mockRequest.body = {
-        serviceType: 'overseerr',
-        baseUrl: 'http://overseerr.example.com',
+        serviceType: 'seerr',
+        baseUrl: 'http://seerr.example.com',
         apiKey: 'test-key',
       };
 
@@ -683,8 +683,8 @@ describe('Services Controller', () => {
 
     it('should return empty object for Overseerr metadata', async () => {
       mockRequest.body = {
-        serviceType: 'overseerr',
-        baseUrl: 'http://overseerr.example.com',
+        serviceType: 'seerr',
+        baseUrl: 'http://seerr.example.com',
         apiKey: 'test-key',
       };
 

--- a/backend/tests/unit/controllers/settings.controller.test.ts
+++ b/backend/tests/unit/controllers/settings.controller.test.ts
@@ -345,7 +345,7 @@ describe('Settings Controller', () => {
       expect(mockResponse.json).toHaveBeenCalledWith({
         success: true,
         data: {
-          version: '1.2.1',
+          version: '1.3.0',
           exportedAt: expect.any(String),
           data: {
             whatsappConnection: {
@@ -459,7 +459,7 @@ describe('Settings Controller', () => {
   describe('importData', () => {
     it('should import data successfully', async () => {
       const importDataPayload = {
-        version: '1.2.1',
+        version: '1.3.0',
         data: {
           services: [
             {
@@ -599,13 +599,13 @@ describe('Settings Controller', () => {
       expect(mockResponse.status).toHaveBeenCalledWith(400);
       expect(mockResponse.json).toHaveBeenCalledWith({
         success: false,
-        message: 'Unsupported schema version: 2.0.0. Expected: 1.2.1',
+        message: 'Unsupported schema version: 2.0.0. Expected: 1.3.0',
       });
     });
 
     it('should skip existing requests during import', async () => {
       const importDataPayload = {
-        version: '1.2.1',
+        version: '1.3.0',
         data: {
           services: [],
           requests: [
@@ -669,7 +669,7 @@ describe('Settings Controller', () => {
     it('should call next on error', async () => {
       const error = new Error('Database error');
       mockRequest.body = {
-        version: '1.2.1',
+        version: '1.3.0',
         data: {
           services: [
             {

--- a/backend/tests/unit/controllers/settings.controller.test.ts
+++ b/backend/tests/unit/controllers/settings.controller.test.ts
@@ -345,7 +345,7 @@ describe('Settings Controller', () => {
       expect(mockResponse.json).toHaveBeenCalledWith({
         success: true,
         data: {
-          version: '1.2.0',
+          version: '1.2.1',
           exportedAt: expect.any(String),
           data: {
             whatsappConnection: {
@@ -459,7 +459,7 @@ describe('Settings Controller', () => {
   describe('importData', () => {
     it('should import data successfully', async () => {
       const importDataPayload = {
-        version: '1.2.0',
+        version: '1.2.1',
         data: {
           services: [
             {
@@ -599,13 +599,13 @@ describe('Settings Controller', () => {
       expect(mockResponse.status).toHaveBeenCalledWith(400);
       expect(mockResponse.json).toHaveBeenCalledWith({
         success: false,
-        message: 'Unsupported schema version: 2.0.0. Expected: 1.2.0',
+        message: 'Unsupported schema version: 2.0.0. Expected: 1.2.1',
       });
     });
 
     it('should skip existing requests during import', async () => {
       const importDataPayload = {
-        version: '1.2.0',
+        version: '1.2.1',
         data: {
           services: [],
           requests: [
@@ -669,7 +669,7 @@ describe('Settings Controller', () => {
     it('should call next on error', async () => {
       const error = new Error('Database error');
       mockRequest.body = {
-        version: '1.2.0',
+        version: '1.2.1',
         data: {
           services: [
             {

--- a/backend/tests/unit/controllers/whatsapp.controller.test.ts
+++ b/backend/tests/unit/controllers/whatsapp.controller.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../../src/services/whatsapp/whatsapp-client.service', () => ({
     getPhoneNumber: vi.fn(),
     initialize: vi.fn(),
     logout: vi.fn(),
+    setMarkOnlineOnConnect: vi.fn(),
   },
 }));
 vi.mock('../../../src/repositories/whatsapp-connection.repository', () => ({

--- a/backend/tests/unit/services/conversation.service.test.ts
+++ b/backend/tests/unit/services/conversation.service.test.ts
@@ -593,7 +593,8 @@ describe('ConversationService', () => {
         session.selectedResult,
         'service1',
         undefined, // selectedSeasons - not set in this test
-        undefined // contactName - not set in this test
+        undefined, // contactName - not set in this test
+        undefined // replyJid - not set in this test
       );
       expect(conversationSessionRepository.update).toHaveBeenCalledWith(sessionId, {
         state: 'IDLE',

--- a/backend/tests/unit/services/media-search/media-search.service.test.ts
+++ b/backend/tests/unit/services/media-search/media-search.service.test.ts
@@ -262,7 +262,7 @@ describe('MediaSearchService', () => {
 
       expect(result).toEqual({
         results: [],
-        searchedServices: ['radarr', 'overseerr'],
+        searchedServices: [],
         failedServices: [],
         fromCache: false,
         searchDuration: expect.any(Number),

--- a/backend/tests/unit/services/media-search/media-search.service.test.ts
+++ b/backend/tests/unit/services/media-search/media-search.service.test.ts
@@ -178,8 +178,8 @@ describe('MediaSearchService', () => {
         {
           id: 3,
           name: 'Test Overseerr',
-          serviceType: 'overseerr' as const,
-          baseUrl: 'http://overseerr:5055',
+          serviceType: 'seerr' as const,
+          baseUrl: 'http://seerr:5055',
           apiKeyEncrypted: 'encrypted-key',
           enabled: true,
           priorityOrder: 1,
@@ -198,7 +198,7 @@ describe('MediaSearchService', () => {
               return Promise.resolve([mockConfigs[0]]);
             case 'sonarr':
               return Promise.resolve([mockConfigs[1]]);
-            case 'overseerr':
+            case 'seerr':
               return Promise.resolve([mockConfigs[2]]);
             default:
               return Promise.resolve([]);
@@ -223,7 +223,7 @@ describe('MediaSearchService', () => {
 
       expect(result).toEqual({
         results: mockResults,
-        searchedServices: ['radarr', 'overseerr'],
+        searchedServices: ['radarr', 'seerr'],
         failedServices: [],
         fromCache: false,
         searchDuration: expect.any(Number),
@@ -392,8 +392,8 @@ describe('MediaSearchService', () => {
         {
           id: 3,
           name: 'Test Overseerr',
-          serviceType: 'overseerr' as const,
-          baseUrl: 'http://overseerr:5055',
+          serviceType: 'seerr' as const,
+          baseUrl: 'http://seerr:5055',
           apiKeyEncrypted: 'encrypted-key',
           enabled: true,
           priorityOrder: 1,
@@ -477,18 +477,18 @@ describe('MediaSearchService', () => {
       });
     });
 
-    it('should fallback to overseerr when primary service not available', async () => {
-      // No radarr configs, but overseerr available
+    it('should fallback to seerr when primary service not available', async () => {
+      // No radarr configs, but seerr available
       vi.mocked(mediaServiceConfigRepository.findEnabledByType).mockImplementation(
         (type: string) => {
           if (type === 'radarr') return Promise.resolve([]);
-          if (type === 'overseerr')
+          if (type === 'seerr')
             return Promise.resolve([
               {
                 id: 3,
                 name: 'Test Overseerr',
-                serviceType: 'overseerr' as const,
-                baseUrl: 'http://overseerr:5055',
+                serviceType: 'seerr' as const,
+                baseUrl: 'http://seerr:5055',
                 apiKeyEncrypted: 'encrypted-key',
                 enabled: true,
                 priorityOrder: 1,
@@ -506,7 +506,7 @@ describe('MediaSearchService', () => {
       const result = await mediaSearchService.getHighestPriorityService('movie');
 
       expect(result).toEqual({
-        serviceType: 'overseerr',
+        serviceType: 'seerr',
         serviceConfigId: 3,
       });
     });

--- a/backend/tests/unit/services/media-search/result-normalizer.test.ts
+++ b/backend/tests/unit/services/media-search/result-normalizer.test.ts
@@ -99,9 +99,9 @@ describe('ResultNormalizerService', () => {
         },
       ];
 
-      const normalized = resultNormalizerService.normalizeRadarrResults(radarrResults, 'overseerr');
+      const normalized = resultNormalizerService.normalizeRadarrResults(radarrResults, 'seerr');
 
-      expect(normalized[0].source).toBe('overseerr');
+      expect(normalized[0].source).toBe('seerr');
     });
   });
 
@@ -199,7 +199,7 @@ describe('ResultNormalizerService', () => {
         tvdbId: null,
         imdbId: 'tt1375666',
         mediaType: 'movie',
-        source: 'overseerr',
+        source: 'seerr',
       });
     });
 
@@ -232,7 +232,7 @@ describe('ResultNormalizerService', () => {
         imdbId: null,
         mediaType: 'series',
         seasonCount: 8,
-        source: 'overseerr',
+        source: 'seerr',
       });
     });
 
@@ -260,7 +260,7 @@ describe('ResultNormalizerService', () => {
         imdbId: null,
         mediaType: 'movie',
         seasonCount: undefined,
-        source: 'overseerr',
+        source: 'seerr',
       });
     });
 
@@ -390,7 +390,7 @@ describe('ResultNormalizerService', () => {
           tmdbId: 999,
           overview: 'Unknown year',
           posterPath: '/unknown.jpg',
-          source: 'overseerr' as const,
+          source: 'seerr' as const,
           tvdbId: null,
           imdbId: null,
         },
@@ -433,7 +433,7 @@ describe('ResultNormalizerService', () => {
         title: 'Overseerr Movie',
         releaseDate: '2019-01-01',
         overview: 'From Overseerr',
-        posterPath: '/overseerr-poster.jpg',
+        posterPath: '/seerr-poster.jpg',
       },
     ];
 
@@ -522,7 +522,7 @@ describe('ResultNormalizerService', () => {
         mediaType: 'movie',
         overview: 'Fallback result',
         posterPath: '/poster.jpg',
-        source: 'overseerr',
+        source: 'seerr',
         tmdbId: null,
         tvdbId: null,
         imdbId: null,
@@ -554,7 +554,7 @@ describe('ResultNormalizerService', () => {
         mediaType: 'movie',
         overview: 'No identifiers',
         posterPath: '/poster.jpg',
-        source: 'overseerr',
+        source: 'seerr',
         tmdbId: null,
         tvdbId: null,
         imdbId: null,

--- a/backend/tests/unit/services/request-approval.service.test.ts
+++ b/backend/tests/unit/services/request-approval.service.test.ts
@@ -870,4 +870,103 @@ describe('RequestApprovalService', () => {
       });
     });
   });
+
+  describe('service type / media type mismatch handling (routing)', () => {
+    const phoneNumberHash = 'hash123';
+    const phoneNumber = '+1234567890';
+
+    beforeEach(() => {
+      vi.mocked(whatsappConnectionRepository.getActive).mockResolvedValue(mockConnection);
+      vi.mocked(encryptionService.decrypt).mockReturnValue('decrypted-key');
+      vi.mocked(encryptionService.encrypt).mockReturnValue('encrypted-phone');
+      vi.mocked(requestHistoryRepository.create).mockResolvedValue({
+        id: 1,
+        status: 'FAILED',
+      } as any);
+    });
+
+    it('radarr service + movie → succeeds (correct routing)', async () => {
+      vi.mocked(mediaServiceConfigRepository.findById).mockResolvedValue({
+        ...mockServiceConfig,
+        serviceType: 'radarr',
+      });
+      const mockRadarrClient = { addMovie: vi.fn().mockResolvedValue(undefined) };
+      vi.mocked(RadarrClient).mockImplementation(() => mockRadarrClient as any);
+      vi.mocked(requestHistoryRepository.create).mockResolvedValue({
+        id: 1,
+        status: 'SUBMITTED',
+      } as any);
+
+      const result = await service.createAndProcessRequest(
+        phoneNumberHash,
+        phoneNumber,
+        { ...mockSelectedResult, mediaType: 'movie' },
+        1
+      );
+
+      expect(result.status).toBe('SUBMITTED');
+      expect(mockRadarrClient.addMovie).toHaveBeenCalled();
+    });
+
+    it('sonarr service + series → succeeds (correct routing)', async () => {
+      vi.mocked(mediaServiceConfigRepository.findById).mockResolvedValue({
+        ...mockServiceConfig,
+        serviceType: 'sonarr',
+      });
+      const mockSonarrClient = { addSeries: vi.fn().mockResolvedValue(undefined) };
+      vi.mocked(SonarrClient).mockImplementation(() => mockSonarrClient as any);
+      vi.mocked(requestHistoryRepository.create).mockResolvedValue({
+        id: 1,
+        status: 'SUBMITTED',
+      } as any);
+
+      const result = await service.createAndProcessRequest(
+        phoneNumberHash,
+        phoneNumber,
+        { ...mockSelectedResult, mediaType: 'series' },
+        1
+      );
+
+      expect(result.status).toBe('SUBMITTED');
+      expect(mockSonarrClient.addSeries).toHaveBeenCalled();
+    });
+
+    it('radarr service + series (TV) → returns clear error message', async () => {
+      vi.mocked(mediaServiceConfigRepository.findById).mockResolvedValue({
+        ...mockServiceConfig,
+        serviceType: 'radarr',
+      });
+
+      const result = await service.createAndProcessRequest(
+        phoneNumberHash,
+        phoneNumber,
+        { ...mockSelectedResult, mediaType: 'series' },
+        1
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.status).toBe('FAILED');
+      expect(result.errorMessage).toContain("Radarr");
+      expect(result.errorMessage).toContain("TV series");
+    });
+
+    it('sonarr service + movie → returns clear error message', async () => {
+      vi.mocked(mediaServiceConfigRepository.findById).mockResolvedValue({
+        ...mockServiceConfig,
+        serviceType: 'sonarr',
+      });
+
+      const result = await service.createAndProcessRequest(
+        phoneNumberHash,
+        phoneNumber,
+        { ...mockSelectedResult, mediaType: 'movie' },
+        1
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.status).toBe('FAILED');
+      expect(result.errorMessage).toContain("Sonarr");
+      expect(result.errorMessage).toContain("movie");
+    });
+  });
 });

--- a/backend/tests/unit/services/request-approval.service.test.ts
+++ b/backend/tests/unit/services/request-approval.service.test.ts
@@ -315,8 +315,8 @@ describe('RequestApprovalService', () => {
           });
         });
 
-        it('should submit to overseerr for movie', async () => {
-          const overseerrConfig = { ...mockServiceConfig, serviceType: 'overseerr' as const };
+        it('should submit to seerr for movie', async () => {
+          const overseerrConfig = { ...mockServiceConfig, serviceType: 'seerr' as const };
 
           vi.mocked(mediaServiceConfigRepository.findById).mockResolvedValue(overseerrConfig);
 
@@ -343,9 +343,9 @@ describe('RequestApprovalService', () => {
           });
         });
 
-        it('should submit to overseerr for series', async () => {
+        it('should submit to seerr for series', async () => {
           const seriesResult = { ...mockSelectedResult, mediaType: 'series' as const };
-          const overseerrConfig = { ...mockServiceConfig, serviceType: 'overseerr' as const };
+          const overseerrConfig = { ...mockServiceConfig, serviceType: 'seerr' as const };
 
           vi.mocked(mediaServiceConfigRepository.findById).mockResolvedValue(overseerrConfig);
 
@@ -467,8 +467,8 @@ describe('RequestApprovalService', () => {
           });
         });
 
-        it('should handle overseerr with no default server', async () => {
-          const overseerrConfig = { ...mockServiceConfig, serviceType: 'overseerr' as const };
+        it('should handle seerr with no default server', async () => {
+          const overseerrConfig = { ...mockServiceConfig, serviceType: 'seerr' as const };
 
           vi.mocked(mediaServiceConfigRepository.findById).mockResolvedValue(overseerrConfig);
 
@@ -486,7 +486,7 @@ describe('RequestApprovalService', () => {
 
           expect(result).toEqual({
             success: false,
-            errorMessage: 'No Radarr server configured in Overseerr',
+            errorMessage: 'No Radarr server configured in Seerr',
             status: 'FAILED',
           });
         });

--- a/docs/superpowers/specs/2026-05-02-auto-routing-fix-plan.md
+++ b/docs/superpowers/specs/2026-05-02-auto-routing-fix-plan.md
@@ -1,0 +1,65 @@
+# Implementation Plan: Movie→Radarr / TV→Sonarr Auto-Routing Fix (P1-C)
+Date: 2026-05-02
+
+## Problem
+When a user has both Radarr and Sonarr configured (without Overseerr), the service selection picks the highest-priority config regardless of media type. A user reported: "it identified the target was a movie, but tried to pass it to Sonarr."
+
+## Root Cause
+`request-approval.service.ts` calls `mediaServiceConfigRepository.findById(serviceConfigId)` where `serviceConfigId` comes from `conversation.service.ts`. The conversation service selects the service config once (at the start of a session or search) without considering whether it matches the media type of the final selection.
+
+## Fix
+
+### Step 1 — Find where serviceConfigId is chosen
+**File:** `backend/src/services/conversation/conversation.service.ts`
+- Find where `serviceConfigId` is set on the conversation session (likely during `performSearch` or `AWAITING_SELECTION` handling)
+- This is the selection point to fix
+
+### Step 2 — Prefer type-appropriate service at selection time
+When the user's selection is resolved (i.e., `selectedResult.mediaType` is known), re-select the service config to prefer a type-appropriate service:
+
+```typescript
+// In conversation.service.ts, after selectedResult is determined:
+const preferredServiceType = selectedResult.mediaType === 'movie' ? 'radarr' : 'sonarr';
+let serviceConfigId = session.serviceConfigId; // current default
+
+// Try to find a type-appropriate config
+const allConfigs = await mediaServiceConfigRepository.findAll(); // or findEnabled()
+const typeMatch = allConfigs.find(c => c.serviceType === preferredServiceType && c.isEnabled);
+if (typeMatch) {
+  serviceConfigId = typeMatch.id;
+} else {
+  // Fall back to overseerr/jellyseerr, then whatever is available
+  const seerrMatch = allConfigs.find(c =>
+    (c.serviceType === 'overseerr' || c.serviceType === 'jellyseerr') && c.isEnabled
+  );
+  if (seerrMatch) serviceConfigId = seerrMatch.id;
+  // else keep session.serviceConfigId
+}
+```
+
+### Step 3 — Handle mismatch gracefully in `executeRequest`
+**File:** `backend/src/services/conversation/request-approval.service.ts` — `executeRequest()` (~line 258)
+- Already has `else if (serviceType === 'radarr' && mediaType === 'movie')` and `else if (serviceType === 'sonarr' && mediaType === 'series')` guards
+- After Step 2 fix this should rarely be hit, but add a clear error message if it is:
+  ```
+  "Sorry, the configured service (Radarr) can't handle TV series requests. Please contact your admin."
+  ```
+- Currently it silently falls through — add explicit error handling
+
+### Step 4 — Unit Tests
+**File:** `backend/src/services/conversation/__tests__/request-approval.service.test.ts` (or similar)
+- Test: movie selected + only Radarr configured → routes to Radarr ✓
+- Test: TV selected + only Sonarr configured → routes to Sonarr ✓
+- Test: movie selected + only Sonarr configured → returns clear error ✓
+- Test: movie selected + both Radarr and Sonarr configured → routes to Radarr ✓
+- Test: TV selected + both Radarr and Sonarr configured → routes to Sonarr ✓
+- Test: movie selected + Overseerr configured → routes to Overseerr ✓ (no change)
+
+## Acceptance Criteria
+- [ ] Movie request with Radarr+Sonarr both configured → goes to Radarr
+- [ ] TV request with Radarr+Sonarr both configured → goes to Sonarr
+- [ ] Movie request with only Sonarr → clear error message sent to user
+- [ ] TV request with only Radarr → clear error message sent to user
+- [ ] Overseerr/Jellyseerr configs are unaffected (they handle both types internally)
+- [ ] All existing tests pass
+- [ ] New tests added and passing

--- a/docs/superpowers/specs/2026-05-02-backlog-all-features.md
+++ b/docs/superpowers/specs/2026-05-02-backlog-all-features.md
@@ -1,0 +1,177 @@
+# WAMR Feature Backlog — All Planned Improvements
+Generated: 2026-05-02
+Source: Reddit user feedback across r/sonarr, r/radarr, r/selfhosted threads
+
+---
+
+## Priority 1 — Stability & Accessibility (Blocking Users)
+
+### [P1-A] Jellyseerr Support
+**User demand:** Requested in r/radarr and r/selfhosted. Overseerr and Jellyseerr are converging into "Seerr" but users need Jellyseerr support now.
+**What:** Add `jellyseerr` as a valid `serviceType`. Jellyseerr's API is compatible with Overseerr v1 API surface, so it's largely a config change + label update.
+**Scope:**
+- Add `'jellyseerr'` to `serviceType` enum in DB schema (migration required)
+- Add `JellyseerrClient` (or reuse `OverseerrClient` with a type alias)
+- Update frontend service config form to show Jellyseerr as an option
+- Update `mediaSearchService`, `requestApprovalService`, `conversationService` to handle `jellyseerr` serviceType
+- Update documentation and screenshots
+**Files:** `backend/src/db/schema.ts`, `backend/src/services/integrations/overseerr.client.ts`, `backend/src/services/integrations/media-search.service.ts`, `backend/src/services/conversation/request-approval.service.ts`, frontend service config components
+**Effort:** Small-Medium (API is compatible, mostly plumbing)
+
+---
+
+### [P1-B] Movie Posters in WhatsApp Search Results
+**User demand:** "any thoughts on adding posters to the search results like Addarr does for Telegram?" — BGentler, r/selfhosted
+**What:** When returning search results to WhatsApp, send the movie/show poster image alongside (or instead of) text-only results.
+**Scope:**
+- Add `sendImage(recipient, imageUrl, caption)` method to `WhatsAppClientService`
+  - Baileys supports `{ image: { url: '...' }, caption: '...' }` message type
+- Fetch poster URL: already available as `posterPath` in `NormalizedResult` (never used currently)
+  - Poster base URLs: TMDB (`https://image.tmdb.org/t/p/w500{posterPath}`), Overseerr (`{baseUrl}/imageproxy/...`)
+- Option A: Send one image per result (noisy for 5 results)
+- Option B: Send a collage/grid (complex)
+- Option C: Send text list as before, but when user selects a result, send the poster for that specific title as confirmation
+  - **Recommended** — less noise, better UX, simpler to implement
+- Make this configurable via admin settings (on/off toggle: "Send poster on selection")
+**Files:** `backend/src/services/whatsapp/whatsapp-client.service.ts`, `backend/src/services/conversation/conversation.service.ts`, `backend/src/db/schema.ts` (settings), frontend settings page
+**Effort:** Medium
+**Note:** Baileys `sendMessage` with `{ image: { url } }` requires the URL to be publicly reachable OR fetch the buffer first. Prefer fetching the image buffer in the backend and sending as `{ image: Buffer }`.
+
+---
+
+### [P1-C] Automatic Movie→Radarr / TV→Sonarr Routing
+**User demand:** "Is there a way to automatically map movies→radarr, and tv→sonarr?" — Rtwose, r/sonarr v1.1.0. "it identified the target was a movie, but tried to pass it to Sonarr" — Rtwose
+**What:** When a user selects a search result, the system should automatically route movies to Radarr and TV series to Sonarr (when both are configured), without requiring Overseerr.
+**Current state:** `request-approval.service.ts` picks the highest-priority service regardless of media type. When both Radarr and Sonarr are configured, it may route a movie to Sonarr.
+**Scope:**
+- In `request-approval.service.ts`, when selecting a service config:
+  - If `selectedResult.mediaType === 'movie'` → prefer `serviceType === 'radarr'` configs
+  - If `selectedResult.mediaType === 'series'` → prefer `serviceType === 'sonarr'` configs
+  - Fallback to Overseerr/Jellyseerr if no direct match
+  - If still no match, use highest priority (current behavior)
+- Add unit tests covering all routing combinations
+**Files:** `backend/src/services/conversation/request-approval.service.ts`
+**Effort:** Small
+
+---
+
+### [P1-D] Per-User Request Quotas
+**User demand:** "Can't let my family in on this, my server would overload" — Supaastahhmarioo, r/sonarr v1.1.0
+**What:** Allow admin to set a max number of requests per user per time window (daily/weekly). Users who hit the limit get a friendly WhatsApp message.
+**Scope:**
+- New DB table: `request_quotas` — `{ id, phoneNumberHash, windowType ('daily'|'weekly'|'monthly'), maxRequests, createdAt }`
+  OR use the existing `settings` table with a global quota key
+- Global quota setting in admin Settings page: "Max requests per user" + "Per window (daily/weekly/monthly)"
+- Per-contact override: allow setting a different quota on the Contacts page
+- In `request-approval.service.ts`, before approving:
+  - Count requests from this `phoneNumberHash` in the current window from `request_history`
+  - If count >= quota, reject with message: "You've reached your {N} request limit for this {window}. Try again {next reset time}."
+- Admin dashboard: show quota usage per contact in Contacts page
+**Files:** `backend/src/db/schema.ts` (new migration), `backend/src/services/conversation/request-approval.service.ts`, `backend/src/api/` (settings endpoints), frontend settings + contacts pages
+**Effort:** Medium
+
+---
+
+## Priority 2 — Developer Experience & Ecosystem
+
+### [P2-A] Seerr (Overseerr+Jellyseerr unified) Support
+**Context:** The Overseerr and Jellyseerr teams are merging into "Seerr" (seerr.dev). Once released, add `seerr` as a service type. The API is expected to be backward-compatible.
+**Scope:** Same as P1-A but for the new unified service. Monitor seerr.dev for stable release.
+**Effort:** Tiny (once P1-A is done)
+
+### [P2-B] Ombi Support
+**User demand:** "I'd like to use this but I use ombi" — No-Entry1706, r/sonarr
+**What:** Add Ombi as a supported media service backend.
+**Scope:**
+- Add `OmbiClient` implementing the same interface as `OverseerrClient`
+  - `GET /api/v1/Search/movie/{query}` and `GET /api/v1/Search/tv/{query}` for search
+  - `POST /api/v1/Request/movie` and `POST /api/v1/Request/tv` for requests
+- Add `'ombi'` to `serviceType` enum
+- Update schema, search service, request approval, and frontend
+**Files:** Same pattern as P1-A
+**Effort:** Medium (different API shape requires a proper new client)
+
+### [P2-C] AI / Natural Language Conversation
+**User demand:** Multiple users expected real NLP. One user noted they built an n8n+AI Telegram bot. Espumma called out the misleading "natural conversation" marketing.
+**What:** Replace keyword-based intent parsing with an LLM call that understands free-form requests like "something scary to watch tonight", "the new Marvel movie", "the show about the chemistry teacher who makes drugs".
+**Scope:**
+- Add optional LLM integration (OpenAI-compatible endpoint, configurable in settings)
+- When a message arrives and `AI_ENABLED=true`, route through LLM to extract:
+  - Intent: search / status check / cancel
+  - Media type: movie / series / either
+  - Query: the cleaned search term
+- Replace `intent-parser.ts` logic with LLM call (with fallback to current keyword parser if LLM is unavailable)
+- Add admin settings: LLM provider (OpenAI, Ollama, custom), API key, model name
+- Keep current keyword-based parser as fallback for offline/no-AI setups
+**Files:** `backend/src/services/conversation/intent-parser.ts`, new `llm.service.ts`, admin settings
+**Effort:** Large
+
+### [P2-D] WhatsApp Business API Support
+**User demand:** "Does this bot use my WhatsApp account? Then it's a hard no for me." — beeartic. Multiple users concerned about using personal number.
+**What:** Add support for using a dedicated phone number / WhatsApp Business API (Meta Cloud API or self-hosted) so users don't need to use their personal account.
+**Scope:**
+- Add `WHATSAPP_MODE` env var: `baileys` (current, personal account) or `cloud_api` (Meta WhatsApp Cloud API)
+- In `cloud_api` mode, use Meta's official REST API instead of Baileys
+  - Webhook endpoint to receive messages
+  - REST calls to send messages
+- Document how to get a WhatsApp Business API number (Meta Developer portal)
+**Files:** New `whatsapp-cloud.service.ts`, `whatsapp-client.service.ts` refactor to be interface-based, `index.ts`
+**Effort:** Large
+
+### [P2-E] TrueNAS Scale / Helm Chart Support
+**User demand:** Requested in multiple threads.
+**What:** Publish a TrueNAS Scale app manifest (truecharts-style) and/or a Helm chart.
+**Scope:**
+- Write `Chart.yaml`, `values.yaml`, and templates for Kubernetes/Helm deployment
+- Or write a TrueNAS Scale app `app.yaml` following TrueCharts format
+- CI: publish chart to GitHub Pages
+**Effort:** Medium (mostly YAML)
+
+---
+
+## Priority 3 — UX Polish
+
+### [P3-A] Improved Onboarding / First-Run UX
+**User demand:** Multiple users confused about how to send the first request. "I can't work out how to actually submit a request." "Is there a particular syntax I need to use?"
+**What:** After WhatsApp connects, send the bot account a welcome message explaining how to use it. Also improve the admin dashboard onboarding checklist.
+**Scope:**
+- After WhatsApp connects and is confirmed working, send an auto-introduction message to the admin's own number: "WAMR is connected! Your users can now request media by messaging this number. Configure a prefix in Settings to filter messages."
+- In the dashboard, add a "Getting Started" checklist (1. Connect WhatsApp ✓, 2. Add a media service, 3. Set a message filter, 4. Share your number with users)
+- Improve the Settings page with inline help text explaining the prefix/keyword filter
+**Files:** `backend/src/services/whatsapp/`, frontend Dashboard/Settings pages
+**Effort:** Small
+
+### [P3-B] "It's Ready!" Download Complete Notifications
+**Context:** The DB schema already has `notifiedSeasons` and `notifiedEpisodes` fields — notifications were partially planned. The `media-monitoring/` service directory exists.
+**What:** When Sonarr/Radarr finishes downloading content, send the requester a WhatsApp message: "Good news! [Movie Title] is now available."
+**Scope:**
+- Webhook receiver: `POST /api/webhooks/sonarr` and `POST /api/webhooks/radarr` (already partially exists per the `media-monitoring` service)
+- On webhook: match the downloaded title to a pending `request_history` entry via `tmdbId`/`tvdbId`
+- Look up the requester's encrypted phone number from `request_history`
+- Send a WhatsApp notification using `whatsappClientService.sendMessage()`
+- Update `notifiedSeasons`/`notifiedEpisodes` to avoid duplicate notifications
+- Admin dashboard: toggle "Enable download notifications" per service
+**Files:** `backend/src/services/media-monitoring/`, `backend/src/api/routes/`, `backend/src/db/schema.ts`
+**Effort:** Medium (infrastructure partially exists)
+
+### [P3-C] Request Status Check via WhatsApp
+**What:** Let users message the bot to check the status of their pending requests: "what's the status of my requests?" → bot replies with a list of their pending/approved/downloading requests.
+**Scope:**
+- Add intent detection for status queries in `intent-parser.ts`
+- Query `request_history` by `phoneNumberHash` for recent requests
+- Format and return status list
+**Files:** `backend/src/services/conversation/intent-parser.ts`, `conversation.service.ts`
+**Effort:** Small
+
+---
+
+## Implementation Order Recommendation
+
+```
+Phase 1 (now):    P1-C (auto-routing) + P1-A (Jellyseerr)     ← parallel
+Phase 2 (next):   P1-B (posters) + P1-D (quotas)              ← parallel
+Phase 3:          P3-B (notifications) + P3-A (onboarding)     ← parallel
+Phase 4:          P2-B (Ombi) + P3-C (status check)            ← parallel
+Phase 5:          P2-C (AI) + P2-D (Business API)              ← sequential (large)
+Phase 6:          P2-A (Seerr) + P2-E (TrueNAS)                ← whenever ready
+```

--- a/docs/superpowers/specs/2026-05-02-jellyseerr-support-plan.md
+++ b/docs/superpowers/specs/2026-05-02-jellyseerr-support-plan.md
@@ -1,0 +1,58 @@
+# Implementation Plan: Jellyseerr Support (P1-A)
+Date: 2026-05-02
+
+## Goal
+Add `jellyseerr` as a supported service type alongside `overseerr`. Jellyseerr's API is 99% compatible with Overseerr v1, so the implementation is mostly plumbing and labeling.
+
+## Steps
+
+### 1. DB Schema Migration
+**File:** `backend/src/db/schema.ts`
+- Add `'jellyseerr'` to the `serviceType` enum in `mediaServiceConfigurations` table
+- Add `'jellyseerr'` to the `serviceType` enum in `requestHistory` table
+
+**File:** `backend/drizzle/` — generate a new migration:
+```bash
+cd backend && npm run db:generate
+```
+
+### 2. Backend — Service Client
+**File:** `backend/src/services/integrations/overseerr.client.ts`
+- The `OverseerrClient` class works as-is for Jellyseerr (same API)
+- Add a type alias / factory: `export const JellyseerrClient = OverseerrClient`
+- OR: export a single `SeerrClient` that accepts `serviceType: 'overseerr' | 'jellyseerr'` (cosmetic only)
+
+### 3. Backend — Media Search Service
+**File:** `backend/src/services/integrations/media-search.service.ts`
+- Wherever `serviceType === 'overseerr'` is checked, add `|| serviceType === 'jellyseerr'`
+- Both use the same client class
+
+### 4. Backend — Request Approval Service
+**File:** `backend/src/services/conversation/request-approval.service.ts`
+- Same pattern: wherever `overseerr` is checked, also handle `jellyseerr`
+- When instantiating the client for a `jellyseerr` config, use `OverseerrClient` (or `SeerrClient`)
+
+### 5. Backend — Integration Test
+**File:** `backend/src/services/integrations/__tests__/` or wherever integration tests live
+- Add a test case for `jellyseerr` serviceType config, verifying search and request paths work
+
+### 6. Frontend — Service Config Form
+**File:** `frontend/src/` — find the media service configuration form/component
+- Add `jellyseerr` as an option in the service type dropdown
+- Label it "Jellyseerr"
+- Use same fields as Overseerr (base URL, API key) — no extra fields needed
+- Display name in requests list as "Jellyseerr"
+
+### 7. Documentation
+- Update README.md: add Jellyseerr to the "Service Integration" feature bullet and the supported services list
+- Update ENVIRONMENT.md if there are any Jellyseerr-specific notes
+- Update SCREENSHOTS.md if screenshots show the service type dropdown
+
+## Acceptance Criteria
+- [ ] Can add a Jellyseerr service config in admin dashboard
+- [ ] Connection test works for a Jellyseerr instance
+- [ ] Search returns results when Jellyseerr is the active service
+- [ ] Movie and TV requests are submitted successfully via Jellyseerr
+- [ ] `request_history` records show `serviceType = 'jellyseerr'`
+- [ ] All existing Overseerr tests still pass
+- [ ] New tests for Jellyseerr code paths pass

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wamr-frontend",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "WhatsApp Media Request Manager - Admin Dashboard",
   "type": "module",
   "scripts": {

--- a/frontend/src/components/services/service-form.tsx
+++ b/frontend/src/components/services/service-form.tsx
@@ -401,8 +401,6 @@ export function ServiceForm({ service, open, onClose, onSuccess }: ServiceFormPr
             >
               <option value="radarr">Radarr</option>
               <option value="sonarr">Sonarr</option>
-              <option value="overseerr">Overseerr</option>
-              <option value="jellyseerr">Jellyseerr</option>
               <option value="seerr">Seerr (recommended)</option>
             </select>
           </div>

--- a/frontend/src/components/services/service-form.tsx
+++ b/frontend/src/components/services/service-form.tsx
@@ -402,6 +402,8 @@ export function ServiceForm({ service, open, onClose, onSuccess }: ServiceFormPr
               <option value="radarr">Radarr</option>
               <option value="sonarr">Sonarr</option>
               <option value="overseerr">Overseerr</option>
+              <option value="jellyseerr">Jellyseerr</option>
+              <option value="seerr">Seerr (recommended)</option>
             </select>
           </div>
 

--- a/frontend/src/components/services/service-list.tsx
+++ b/frontend/src/components/services/service-list.tsx
@@ -82,6 +82,8 @@ export function ServiceList({ services, isLoading, onEdit }: ServiceListProps) {
       radarr: 'default',
       sonarr: 'secondary',
       overseerr: 'outline',
+      jellyseerr: 'outline',
+      seerr: 'outline',
     };
 
     return (

--- a/frontend/src/components/services/service-list.tsx
+++ b/frontend/src/components/services/service-list.tsx
@@ -81,8 +81,6 @@ export function ServiceList({ services, isLoading, onEdit }: ServiceListProps) {
     const variants: Record<string, 'default' | 'secondary' | 'outline'> = {
       radarr: 'default',
       sonarr: 'secondary',
-      overseerr: 'outline',
-      jellyseerr: 'outline',
       seerr: 'outline',
     };
 

--- a/frontend/src/types/request.types.ts
+++ b/frontend/src/types/request.types.ts
@@ -1,6 +1,6 @@
 export type RequestStatus = 'PENDING' | 'APPROVED' | 'REJECTED' | 'SUBMITTED' | 'FAILED';
 export type MediaType = 'movie' | 'series';
-export type ServiceType = 'radarr' | 'sonarr' | 'overseerr';
+export type ServiceType = 'radarr' | 'sonarr' | 'overseerr' | 'jellyseerr';
 
 export interface MediaRequest {
   id: number;

--- a/frontend/src/types/request.types.ts
+++ b/frontend/src/types/request.types.ts
@@ -1,6 +1,6 @@
 export type RequestStatus = 'PENDING' | 'APPROVED' | 'REJECTED' | 'SUBMITTED' | 'FAILED';
 export type MediaType = 'movie' | 'series';
-export type ServiceType = 'radarr' | 'sonarr' | 'overseerr' | 'jellyseerr';
+export type ServiceType = 'radarr' | 'sonarr' | 'seerr';
 
 export interface MediaRequest {
   id: number;

--- a/frontend/src/types/service.types.ts
+++ b/frontend/src/types/service.types.ts
@@ -1,7 +1,7 @@
 /**
  * Service types
  */
-export type ServiceType = 'radarr' | 'sonarr' | 'overseerr';
+export type ServiceType = 'radarr' | 'sonarr' | 'overseerr' | 'jellyseerr' | 'seerr';
 
 /**
  * Service configuration

--- a/frontend/src/types/service.types.ts
+++ b/frontend/src/types/service.types.ts
@@ -1,7 +1,7 @@
 /**
  * Service types
  */
-export type ServiceType = 'radarr' | 'sonarr' | 'overseerr' | 'jellyseerr' | 'seerr';
+export type ServiceType = 'radarr' | 'sonarr' | 'seerr';
 
 /**
  * Service configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       ],
       "dependencies": {
         "@whiskeysockets/baileys": "^6.7.16",
+        "opencode-codebase-index": "^0.7.0",
         "tsx": "^4.21.0"
       },
       "devDependencies": {
@@ -9859,6 +9860,46 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.3.17",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.3.17.tgz",
+      "integrity": "sha512-N5lckFtYvEu2R8K1um//MIOTHsJHniF2kHoPIWPCrxKG5Jpismt1ISGzIiU3aKI2ht/9VgcqKPC5oZFLdmpxPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/sdk": "1.3.17",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.1.96",
+        "@opentui/solid": ">=0.1.96"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/plugin/node_modules/zod": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
+      "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.3.17",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.3.17.tgz",
+      "integrity": "sha512-2+MGgu7wynqTBwxezR01VAGhILXlpcHDY/pF7SWB87WOgLt3kD55HjKHNj6PWxyY8n575AZolR95VUC3gtwfmA==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
@@ -11486,6 +11527,21 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
@@ -12773,6 +12829,15 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -12863,6 +12928,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-network-error": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
+      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -13524,6 +13601,42 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/opencode-codebase-index": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/opencode-codebase-index/-/opencode-codebase-index-0.7.0.tgz",
+      "integrity": "sha512-+yraevMYtdxYGgPsfTSE3KmajE7Iq9HNgo36bI36TQxFNZOI2h5MZc1+MXL/wwUBK6CDDsaSO/8YYDjfXRPRJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/plugin": "~1.3.13",
+        "chokidar": "^5.0.0",
+        "ignore": "^7.0.5",
+        "p-queue": "^9.1.1",
+        "p-retry": "^7.1.1",
+        "tiktoken": "^1.0.15"
+      },
+      "bin": {
+        "opencode-codebase-index-mcp": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@opencode-ai/plugin": "^1.0.0",
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        },
+        "@opencode-ai/plugin": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -13579,6 +13692,49 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.2.0.tgz",
+      "integrity": "sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-7.1.1.tgz",
+      "integrity": "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -14128,6 +14284,19 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/real-require": {
@@ -14707,6 +14876,12 @@
       "dependencies": {
         "real-require": "^0.2.0"
       }
+    },
+    "node_modules/tiktoken": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/tiktoken/-/tiktoken-1.0.22.tgz",
+      "integrity": "sha512-PKvy1rVF1RibfF3JlXBSP0Jrcw2uq3yXdgcEXtKTYn3QJ/cBRBHDnrJ5jHky+MENZ6DIPwNUGWpkVx+7joCpNA==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "dependencies": {
     "@whiskeysockets/baileys": "^6.7.16",
-    "opencode-codebase-index": "^0.7.0",
     "tsx": "^4.21.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wamr-monorepo",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "private": true,
   "description": "WhatsApp Media Request Manager - Monorepo",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@whiskeysockets/baileys": "^6.7.16",
+    "opencode-codebase-index": "^0.7.0",
     "tsx": "^4.21.0"
   }
 }


### PR DESCRIPTION
## What's changed

- **Breaking:** Removed `overseerr` and `jellyseerr` service types — only `seerr` remains (same API surface). Existing DB rows with the old types need a manual update (see below).
- **Fix:** WhatsApp replies silently dropped for LID accounts where `phoneNumber` is undefined — now falls back to `replyJid`.
- **Fix:** `markOnlineOnConnect = false` had no effect — Baileys overrides presence before each send; we now restore `unavailable` afterward.
- **Chore:** Bump version `1.2.1` → `1.3.0`.

## Migration

If upgrading from a version with `overseerr`/`jellyseerr` service entries:

```sql
UPDATE media_service_configs SET service_type = 'seerr' WHERE service_type IN ('overseerr', 'jellyseerr');
UPDATE request_history SET service_type = 'seerr' WHERE service_type IN ('overseerr', 'jellyseerr');
```

## Verification

660 tests passing · lint · format · build all clean