### PR TITLE
fix(docker): suppress MODULE_TYPELESS_PACKAGE_JSON warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && git config --global url."https://github.com/".insteadOf ssh://git@github.com/ \
   && git config --global url."https://github.com/".insteadOf git@github.com:
 
-# Copy package.json files
-COPY package.json ./
+# Copy backend package.json (has "type": "module" needed for ESM runtime)
+COPY backend/package.json ./
 
 # Copy node_modules from builder (already compiled for Node.js ABI)
 COPY --from=builder /app/node_modules ./node_modules


### PR DESCRIPTION
## Problem

After deploying v1.3.0, the container logs show repeated warnings:

```
Warning: Module type of file:///app/dist/database/migrate.js is not specified and it doesn't parse as CommonJS.
Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
To eliminate this warning, add "type": "module" to /app/package.json.
```

## Root Cause

The Dockerfile production stage copies the root `package.json` (no `"type": "module"`) to `/app/package.json`. The backend is built as ESM (`format: 'esm'` in `build.js`), so Node.js defaults to CommonJS, detects `import`/`export` syntax, and re-parses every `.js` file.

## Fix

Copy `backend/package.json` (which already has `"type": "module"`) instead of the root `package.json` in the production stage.

## Verification

- Build, lint, format-check all clean
- The change only affects the Docker production image layout