### PR TITLE
fix(conversation): prevent duplicate contacts for LID users without phone numbers

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wamr-backend",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "WhatsApp Media Request Manager - Backend API",
   "main": "dist/index.js",
   "type": "module",

--- a/backend/src/services/conversation/conversation.service.ts
+++ b/backend/src/services/conversation/conversation.service.ts
@@ -77,12 +77,12 @@ export class ConversationService {
       );
       // When we create a new session and we already have a contact name (from message metadata),
       // persist contact and backfill historical request entries so older requests show a name.
-      if (contactName) {
+      // Only create contacts when we have an actual phone number (not LID-only) to prevent
+      // duplicate contacts with hash IDs showing in the UI.
+      if (contactName && phoneNumber) {
         try {
           // Persist the contact name and backfill historical request entries so older requests show a name.
-          const phoneNumberEncrypted = phoneNumber
-            ? encryptionService.encrypt(phoneNumber)
-            : undefined;
+          const phoneNumberEncrypted = encryptionService.encrypt(phoneNumber);
           await contactRepository.upsert({ phoneNumberHash, contactName, phoneNumberEncrypted });
           // Backfill contact name to existing request_history entries
           await requestHistoryRepository.updateContactNameForPhone(
@@ -112,29 +112,31 @@ export class ConversationService {
       if (updated) {
         session = updated;
 
-        try {
-          // Upsert to contacts list and backfill historical request entries.
-          const phoneNumberEncrypted = phoneNumber
-            ? encryptionService.encrypt(phoneNumber)
-            : undefined;
-          await contactRepository.upsert({ phoneNumberHash, contactName, phoneNumberEncrypted });
-          // Backfill contact name to existing request_history entries
-          await requestHistoryRepository.updateContactNameForPhone(
-            phoneNumberHash,
-            contactName,
-            true
-          );
-          // Emit a socket event so admin clients can update their cached request rows immediately
-          webSocketService.emit(SocketEvents.REQUEST_CONTACT_UPDATE, {
-            phoneNumberHash,
-            contactName,
-            timestamp: new Date().toISOString(),
-          });
-        } catch (err) {
-          logger.warn(
-            { sessionId: session.id, phoneNumberHash, contactName, error: err },
-            'Failed to update contact repository'
-          );
+        // Only update contacts when we have an actual phone number (not LID-only) to prevent
+        // duplicate contacts with hash IDs showing in the UI.
+        if (phoneNumber) {
+          try {
+            // Upsert to contacts list and backfill historical request entries.
+            const phoneNumberEncrypted = encryptionService.encrypt(phoneNumber);
+            await contactRepository.upsert({ phoneNumberHash, contactName, phoneNumberEncrypted });
+            // Backfill contact name to existing request_history entries
+            await requestHistoryRepository.updateContactNameForPhone(
+              phoneNumberHash,
+              contactName,
+              true
+            );
+            // Emit a socket event so admin clients can update their cached request rows immediately
+            webSocketService.emit(SocketEvents.REQUEST_CONTACT_UPDATE, {
+              phoneNumberHash,
+              contactName,
+              timestamp: new Date().toISOString(),
+            });
+          } catch (err) {
+            logger.warn(
+              { sessionId: session.id, phoneNumberHash, contactName, error: err },
+              'Failed to update contact repository'
+            );
+          }
         }
       } else {
         logger.warn({ sessionId: session.id }, 'Failed to update contact name for session');

--- a/backend/tests/unit/controllers/settings.controller.test.ts
+++ b/backend/tests/unit/controllers/settings.controller.test.ts
@@ -345,7 +345,7 @@ describe('Settings Controller', () => {
       expect(mockResponse.json).toHaveBeenCalledWith({
         success: true,
         data: {
-          version: '1.3.0',
+          version: '1.3.1',
           exportedAt: expect.any(String),
           data: {
             whatsappConnection: {
@@ -459,7 +459,7 @@ describe('Settings Controller', () => {
   describe('importData', () => {
     it('should import data successfully', async () => {
       const importDataPayload = {
-        version: '1.3.0',
+        version: '1.3.1',
         data: {
           services: [
             {
@@ -599,13 +599,13 @@ describe('Settings Controller', () => {
       expect(mockResponse.status).toHaveBeenCalledWith(400);
       expect(mockResponse.json).toHaveBeenCalledWith({
         success: false,
-        message: 'Unsupported schema version: 2.0.0. Expected: 1.3.0',
+        message: 'Unsupported schema version: 2.0.0. Expected: 1.3.1',
       });
     });
 
     it('should skip existing requests during import', async () => {
       const importDataPayload = {
-        version: '1.3.0',
+        version: '1.3.1',
         data: {
           services: [],
           requests: [
@@ -669,7 +669,7 @@ describe('Settings Controller', () => {
     it('should call next on error', async () => {
       const error = new Error('Database error');
       mockRequest.body = {
-        version: '1.3.0',
+        version: '1.3.1',
         data: {
           services: [
             {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wamr-frontend",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "WhatsApp Media Request Manager - Admin Dashboard",
   "type": "module",
   "scripts": {

--- a/frontend/src/components/layout/main-layout.tsx
+++ b/frontend/src/components/layout/main-layout.tsx
@@ -48,7 +48,12 @@ export function MainLayout({ children }: MainLayoutProps) {
           >
             <Menu className="h-6 w-6" />
           </button>
-          <h1 className="ml-4 text-lg font-bold">WAMR</h1>
+          <div className="ml-4 flex flex-col justify-center">
+            <h1 className="text-lg font-bold leading-tight">WAMR</h1>
+            <span className="text-[10px] leading-tight text-muted-foreground">
+              v{__APP_VERSION__}
+            </span>
+          </div>
         </header>
 
         {/* Main content */}

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -41,9 +41,14 @@ export function Sidebar({ isOpen = true, onClose }: SidebarProps) {
         )}
       >
         <div className="flex h-16 items-center justify-between border-b px-4">
-          <div className="flex items-center gap-1">
+          <div className="flex items-center gap-2">
             <img src="/logo.png" alt="WAMR Logo" className="h-10 w-10 object-contain" />
-            <h1 className="text-xl font-bold">WAMR</h1>
+            <div className="flex h-10 flex-col justify-center">
+              <h1 className="text-xl font-bold leading-tight">WAMR</h1>
+              <span className="text-[10px] leading-tight text-muted-foreground">
+                v{__APP_VERSION__}
+              </span>
+            </div>
           </div>
           {/* Close button for mobile */}
           {onClose && (

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
+import { readFileSync } from 'fs';
+
+// Read version from frontend package.json
+const pkg = JSON.parse(readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8'));
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -14,6 +18,9 @@ export default defineConfig(({ mode }) => {
 
   return {
     plugins: [react()],
+    define: {
+      __APP_VERSION__: JSON.stringify(pkg.version),
+    },
     resolve: {
       alias: {
         '@': path.resolve(__dirname, './src'),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wamr-monorepo",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "description": "WhatsApp Media Request Manager - Monorepo",
   "workspaces": [


### PR DESCRIPTION
## Bug
LID users without senderPn/remoteJidAlt were creating duplicate contacts with hash IDs (e.g. 29695f7e...e7e8ee9d) instead of matching existing phone-based contacts.

## Root Cause
When phoneNumber is null (LID-only), contactRepository.upsert() was called with a hash derived from the raw LID, which doesn't match the existing contact's phone-number hash.

## Fix
Only auto-create/update contacts when we have an actual phone number. LID-only sessions still work for requests and conversations, but won't spawn ghost contacts.

## Files Changed
- backend/src/services/conversation/conversation.service.ts